### PR TITLE
Lokal kjøring med rollup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN npm ci
 
 COPY . /usr/src/app
 ENV NODE_ENV=production
-RUN npm run build:esm
+RUN npm run build
 
 FROM node:14-alpine AS runtime
 

--- a/craco.config.js
+++ b/craco.config.js
@@ -1,9 +1,0 @@
-const { ESLINT_MODES } = require("@craco/craco");
-const CracoLessPlugin = require("craco-less");
-
-module.exports = {
-  plugins: [{ plugin: CracoLessPlugin }],
-  eslint: {
-    mode: ESLINT_MODES.file,
-  },
-};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1331,17 +1331,6 @@
         "minimist": "^1.2.0"
       }
     },
-    "@craco/craco": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@craco/craco/-/craco-6.1.1.tgz",
-      "integrity": "sha512-4irfOM8RgYNhFJzAXyIuM8CZLju2Jh9GdOem8uqM2/cI2xPulQSxZKU/9q3uiSbFUJfQLi3pomVKii6KzWLu3Q==",
-      "requires": {
-        "cross-spawn": "^7.0.0",
-        "lodash": "^4.17.15",
-        "semver": "^7.3.2",
-        "webpack-merge": "^4.2.2"
-      }
-    },
     "@csstools/convert-colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
@@ -2591,7 +2580,8 @@
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
-      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
+      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
+      "dev": true
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -3176,7 +3166,8 @@
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -4106,7 +4097,8 @@
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "dev": true
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -4666,11 +4658,6 @@
         "wrap-ansi": "^7.0.0"
       }
     },
-    "clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5129,33 +5116,6 @@
         "yaml": "^1.10.0"
       }
     },
-    "craco-less": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/craco-less/-/craco-less-1.17.1.tgz",
-      "integrity": "sha512-T6V1aF3+eQZ22gUigHInX/i+ExPbWrnmdAhtuEXc4mOyhneDifmEzZFseq/BdRy1aUEs9s4z26jTxP+1I6P//g==",
-      "requires": {
-        "less": "^3.11.1",
-        "less-loader": "^6.1.0"
-      },
-      "dependencies": {
-        "less": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/less/-/less-3.13.1.tgz",
-          "integrity": "sha512-SwA1aQXGUvp+P5XdZslUOhhLnClSLIjWvJhmd+Vgib5BFIr9lMNlQwmwUNOjXThF/A0x+MCYYPeWEfeWiLRnTw==",
-          "requires": {
-            "copy-anything": "^2.0.1",
-            "errno": "^0.1.1",
-            "graceful-fs": "^4.1.2",
-            "image-size": "~0.5.0",
-            "make-dir": "^2.1.0",
-            "mime": "^1.4.1",
-            "native-request": "^1.0.5",
-            "source-map": "~0.6.0",
-            "tslib": "^1.10.0"
-          }
-        }
-      }
-    },
     "create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -5205,6 +5165,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -6813,7 +6774,8 @@
     "emojis-list": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "dev": true
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -9892,7 +9854,8 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isobject": {
       "version": "3.0.1",
@@ -11374,6 +11337,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
       "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -11474,35 +11438,6 @@
         "parse-node-version": "^1.0.1",
         "source-map": "~0.6.0",
         "tslib": "^1.10.0"
-      }
-    },
-    "less-loader": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-6.2.0.tgz",
-      "integrity": "sha512-Cl5h95/Pz/PWub/tCBgT1oNMFeH1WTD33piG80jn5jr12T4XbxZcjThwNXDQ7AG649WEynuIzO4b0+2Tn9Qolg==",
-      "requires": {
-        "clone": "^2.1.2",
-        "less": "^3.11.3",
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^2.7.0"
-      },
-      "dependencies": {
-        "less": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/less/-/less-3.13.1.tgz",
-          "integrity": "sha512-SwA1aQXGUvp+P5XdZslUOhhLnClSLIjWvJhmd+Vgib5BFIr9lMNlQwmwUNOjXThF/A0x+MCYYPeWEfeWiLRnTw==",
-          "requires": {
-            "copy-anything": "^2.0.1",
-            "errno": "^0.1.1",
-            "graceful-fs": "^4.1.2",
-            "image-size": "~0.5.0",
-            "make-dir": "^2.1.0",
-            "mime": "^1.4.1",
-            "native-request": "^1.0.5",
-            "source-map": "~0.6.0",
-            "tslib": "^1.10.0"
-          }
-        }
       }
     },
     "leven": {
@@ -11663,6 +11598,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
       "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+      "dev": true,
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -11681,7 +11617,8 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -11824,6 +11761,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -12102,7 +12040,8 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "minipass": {
       "version": "3.1.3",
@@ -12327,6 +12266,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/native-request/-/native-request-1.0.8.tgz",
       "integrity": "sha512-vU2JojJVelUGp6jRcLwToPoWGxSx23z/0iX+I77J3Ht17rf2INGjrhOoQnjVo60nQd8wVsgzKkPfRXBiVdD2ag==",
+      "dev": true,
       "optional": true
     },
     "native-url": {
@@ -13224,7 +13164,8 @@
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
@@ -21168,6 +21109,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
       "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+      "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.5",
         "ajv": "^6.12.4",
@@ -21193,6 +21135,7 @@
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
       "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -21351,6 +21294,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
@@ -21358,7 +21302,8 @@
     "shebang-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
     },
     "shell-quote": {
       "version": "1.7.2",
@@ -24554,14 +24499,6 @@
         }
       }
     },
-    "webpack-merge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
-      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
-      "requires": {
-        "lodash": "^4.17.15"
-      }
-    },
     "webpack-sources": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
@@ -24623,6 +24560,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -25022,7 +24960,8 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yaml": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -3,11 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@craco/craco": "6.1.1",
     "@metrics/prometheus-consumer": "3.0.1",
     "@podium/podlet": "4.4.14",
     "classnames": "2.2.6",
-    "craco-less": "1.17.1",
     "express": "4.17.1",
     "less": "4.1.1",
     "nav-frontend-chevron": "1.0.28",
@@ -52,11 +50,10 @@
     "rollup-plugin-terser": "7.0.2"
   },
   "scripts": {
-    "start": "NODE_ENV=development craco start",
-    "build": "craco build",
+    "start": "rollup -c rollup.config.dev.js -w",
     "build:esm": "rollup -c rollup.config.js",
-    "test": "craco test",
-    "test-ci": "CI=true craco test",
+    "test": "react-scripts test",
+    "test-ci": "CI=true react-scripts test",
     "refresh": "rm -rf node_modules && rm package-lock.json && npm i",
     "podlet": "node podlet.js",
     "bump": "npx npm-check-updates --target minor -u && npm i"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "scripts": {
     "start": "rollup -c rollup.config.dev.js -w",
-    "build:esm": "rollup -c rollup.config.js",
+    "build": "rollup -c rollup.config.prod.js",
     "test": "react-scripts test",
     "test-ci": "CI=true react-scripts test",
     "refresh": "rm -rf node_modules && rm package-lock.json && npm i",

--- a/podlet.js
+++ b/podlet.js
@@ -21,11 +21,11 @@ const podlet = new Podlet({
 });
 
 podlet.css({
-  value: "/dist/generelle-fliser.css",
+  value: "/dist/bundle.css",
 });
 
 podlet.js({
-  value: "/dist/generelle-fliser.esm.js",
+  value: "/dist/bundle.esm.js",
   type: "module",
   defer: true,
 });

--- a/public/index.html
+++ b/public/index.html
@@ -1,4 +1,5 @@
 <body>
   <noscript> You need to enable JavaScript to run this app. </noscript>
   <div id="podlet-dittnav-generelle-fliser"></div>
+  <script src="/dist/generelle-fliser.dev.esm.js" type="module"></script>
 </body>

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <body>
   <noscript> You need to enable JavaScript to run this app. </noscript>
   <div id="podlet-dittnav-generelle-fliser"></div>
-  <script src="/dist/generelle-fliser.dev.esm.js" type="module"></script>
+  <script src="/dist/bundle.dev.esm.js" type="module"></script>
 </body>

--- a/rollup.config.dev.js
+++ b/rollup.config.dev.js
@@ -1,0 +1,51 @@
+import serve from "rollup-plugin-serve";
+import livereload from "rollup-plugin-livereload";
+import babel from "@rollup/plugin-babel";
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
+import replace from "@rollup/plugin-replace";
+import postcss from "rollup-plugin-postcss";
+import postcssLessLoader from "rollup-plugin-postcss-webpack-alias-less-loader";
+import json from "@rollup/plugin-json";
+
+export default {
+  input: "src/index.js",
+  plugins: [
+    replace({
+      "process.env.NODE_ENV": JSON.stringify("development"),
+    }),
+    nodeResolve({
+      extensions: [".js"],
+    }),
+    babel({
+      presets: ["@babel/preset-react"],
+    }),
+    commonjs({
+      include: ["node_modules/**", "src/*"],
+    }),
+    json(),
+    postcss({
+      extract: false,
+      loaders: [
+        postcssLessLoader({
+          nodeModulePath: "./node_modules",
+          aliases: {},
+        }),
+      ],
+    }),
+    serve({
+      open: true,
+      verbose: true,
+      contentBase: ["", "dist", "public"],
+      historyApiFallback: true,
+      host: "localhost",
+      port: 3000,
+    }),
+    livereload({ watch: "dist" }),
+  ],
+  output: {
+    file: "dist/generelle-fliser.dev.esm.js",
+    format: "esm",
+    sourcemap: true,
+  },
+};

--- a/rollup.config.dev.js
+++ b/rollup.config.dev.js
@@ -21,7 +21,7 @@ export default {
       presets: ["@babel/preset-react"],
     }),
     commonjs({
-      include: ["node_modules/**", "src/*"],
+      include: ["node_modules/**"],
     }),
     json(),
     postcss({
@@ -44,7 +44,7 @@ export default {
     livereload({ watch: "dist" }),
   ],
   output: {
-    file: "dist/generelle-fliser.dev.esm.js",
+    file: "dist/bundle.dev.esm.js",
     format: "esm",
     sourcemap: true,
   },

--- a/rollup.config.prod.js
+++ b/rollup.config.prod.js
@@ -36,7 +36,7 @@ export default {
     }),
     json(),
     postcss({
-      extract: path.resolve("dist/generelle-fliser.css"),
+      extract: path.resolve("dist/bundle.css"),
       loaders: [
         postcssLessLoader({
           nodeModulePath: "./node_modules",
@@ -47,7 +47,7 @@ export default {
   ],
   output: [
     {
-      file: "dist/generelle-fliser.esm.js",
+      file: "dist/bundle.esm.js",
       format: "esm",
       plugins: [terser()],
     },

--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,9 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
 import { SWRConfig } from "swr";
+import { worker } from "./mocks/browser";
 
 if (process.env.NODE_ENV === "development") {
-  const { worker } = require("./mocks/browser");
   worker.start();
 }
 


### PR DESCRIPTION
Kjører lokalt med ESM og Rollup. Nå har vi:
```
- rollup.config.dev.js
- rollup.config.prod.js
```
- Fjernet Craco og Craco-less
- PostCSS for å få inn nav-frontend-moduler
- Livereload for hot reloading